### PR TITLE
Clean up RPM spec file to allow building via mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,35 @@
 Build source rpm for cumulus quagga  from cumulus networks github.
 
 Original Source RPM was the Quagga Fedora 23 Source RPM. Changed the source file location and the build config parameters.
+
+## Building RPMs with Mock
+First install Mock and rpmbuild
+
+```
+sudo yum install mock rpm-build
+```
+
+Then create a new `mock` user and add them to the `mock` group:
+
+```
+sudo adduser mock
+sudo usermod -a -G mock
+```
+
+Switch to the `mock` user and check out this repository:
+
+```
+git clone https://github.com/skamithi/quagga-rpm.git rpmbuild
+```
+
+Then you can rebuild the SRPM and RPMs with Mock:
+
+```
+cd rpmbuild/SPECS
+rpmbuild -bs quagga.spec
+cd ../SRPMS
+mock -r <config_file> rebuild <SRPM_file>
+```
+
+Replace `<config_file>` with something like `epel-7-x86_64` or `fedora-23-x86_64`. Available chroot config files
+are available in `/etc/mock/`. Replace `<SRPM_file>` with the resulting SRPM from your `rpmbuild` command.

--- a/SOURCES/0002-configure-ac.patch
+++ b/SOURCES/0002-configure-ac.patch
@@ -5,7 +5,7 @@
  AC_SUBST(pkgsrcrcdir)
  
 -LIBS="$LIBS -L/usr/include/json/ -ljson"
-+LIBS="$LIBS -L/usr/include/json/ -ljson-c"
++LIBS="$LIBS -L/usr/include/json-c/ -ljson-c"
  
  dnl ------------
  dnl Check CFLAGS

--- a/SOURCES/0003-lib-json.patch
+++ b/SOURCES/0003-lib-json.patch
@@ -1,0 +1,12 @@
+diff -ru lib/json.h lib/json.h
+--- lib/json.h	2016-02-05 13:46:29.539124034 -0500
++++ lib/json.h	2016-02-05 13:46:44.190868490 -0500
+@@ -22,7 +22,7 @@
+ #ifndef _QUAGGA_JSON_H
+ #define _QUAGGA_JSON_H
+ 
+-#include <json/json.h>
++#include <json-c/json.h>
+ 
+ extern void json_object_string_add(struct json_object* obj, const char *key,
+                                    const char *s);

--- a/SPECS/quagga.spec
+++ b/SPECS/quagga.spec
@@ -7,12 +7,11 @@
 
 Name: quagga
 Version: 0.99.23.1
-Release: cl2.5+2
+Release: cl2.5+3%{?dist}
 Summary: Routing daemon
 License: GPLv2+
 Group: System Environment/Daemons
 URL: http://www.quagga.net
-#Source0: http://download.savannah.gnu.org/releases/quagga/%{name}-%{version}.tar.xz
 Source0: http://github.com/CumulusNetworks/quagga/archive/cm_2.5.tar.gz
 Source1: quagga-filter-perl-requires.sh
 Source2: quagga-tmpfs.conf
@@ -24,9 +23,9 @@ Source7: quagga.sysconfig
 Source8: quagga.logrotate
 
 BuildRequires: systemd
-BuildRequires: net-snmp-devel autoconf automake gcc gcc-c++ json-devel
+BuildRequires: net-snmp-devel autoconf automake gcc gcc-c++ json-c-devel
 BuildRequires: texinfo libcap-devel texi2html
-BuildRequires: readline readline-devel ncurses ncurses-devel
+BuildRequires: readline readline-devel ncurses ncurses-devel libtool
 Requires: net-snmp ncurses
 Requires(post): systemd /sbin/install-info
 Requires(preun): systemd /sbin/install-info
@@ -36,6 +35,7 @@ Obsoletes: quagga-sysvinit
 
 Patch0: 0001-systemd-change-the-WantedBy-target.patch
 Patch1: 0002-configure-ac.patch
+Patch2: 0003-lib-json.patch
 
 %define __perl_requires %{SOURCE1}
 
@@ -78,6 +78,7 @@ developing OSPF-API and quagga applications.
 
 %patch0 -p1
 %patch1 -p0
+%patch2 -p0
 
 %build
 libtoolize --force
@@ -237,6 +238,10 @@ fi
 %{_includedir}/quagga/ospfd/*.h
 
 %changelog
+* Fri Feb 05 2016 Leif Madsen <lmadsen@redhat.com>
+- Minor cleanup of the RPM spec file
+- Allow building on both EPEL 7 and Fedora 23
+
 * Wed Jan 20 2016 Stanley Karunditu <stanleyk@cumulusnetworks.com>
 - Build cumulus linux 2.5 version using latest available SPEC file
 
@@ -258,7 +263,7 @@ fi
 * Mon May 26 2014 Michal Sekletar <msekleta@redhat.com> - 0.99.22.4-4
 - raise privileges before creating netlink socket (#1097684)
 
-* Thu Jan 29 2014 Michal Sekletar <msekleta@redhat.com> - 0.99.22.4-3
+* Wed Jan 29 2014 Michal Sekletar <msekleta@redhat.com> - 0.99.22.4-3
 - fix source url
 - fix date in the changelog
 


### PR DESCRIPTION
- update quagga.spec so rpmlint doesn't return errors
- add patch to allow building quagga on EPEL 7 and Fedora 23
- add documentation on how to build with mock
- bump version to cl2.5+3
